### PR TITLE
Fix class scope

### DIFF
--- a/app/controllers/maily_herald/webui/application_controller.rb
+++ b/app/controllers/maily_herald/webui/application_controller.rb
@@ -8,7 +8,7 @@ module MailyHerald
       helper_method :settings
 
       def settings
-        Settings.new(cookies)
+        MailyHerald::Webui::Settings.new(cookies)
       end
 
       def log_scope


### PR DESCRIPTION
Prefix `Settings` class name with full namespace to avoid collision with existing class.
